### PR TITLE
Fix activities without view url

### DIFF
--- a/ajax.php
+++ b/ajax.php
@@ -49,7 +49,11 @@ if (\availability_password\condition::submit_password_for_cm($cm, $password)) {
     $modinfo = get_fast_modinfo($course);
     $cminfo = $modinfo->get_cm($cm->id);
     if ($cminfo->available) {
-        $ret->redirect = $cm->url->out(false);
+        if (!empty($cm->url)) {
+            $ret->redirect = $cm->url->out(false);
+        } else {
+            $ret->redirect = course_get_url($cm->course, $cm->sectionnum)->out(false);
+        }
     }
 }
 


### PR DESCRIPTION
If you add this restriction to an activity that has no view page, you see an error message after entering the password (calling ->out() on null). This patch fixes that (I'm aware, that this is quite a rare use case).